### PR TITLE
[WIP] Move away from deprecated tokio-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ multimap = "0.4"
 net2 = "0.2"
 nix = "0.10"
 rand = "0.5"
-tokio-core = "0.1"
+tokio = "0.1"
 quick-error = "1.2"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
[`tokio-core`](https://github.com/tokio-rs/tokio-core) is deprecated in favor of [`tokio`](https://github.com/tokio-rs/tokio), and libraries should use [tokio sub crates](https://github.com/tokio-rs/tokio#project-layout).

The current commits change the dependency from `tokio-core` to `tokio`, but I'd like to take the opportunity to make the switch to tokio sub crates.
This would probably require breaking API changes.

Here's what I think would work and be idiomatic:
 - merge `FSM` into `Responder`
 - create `ServicesManager` struct to (un)register independently from the `FSM`/`Responder`
 - provide utility methods on the new `Responder` to simplify upgrade for library users

This would allow using libmdns like so:
```rust
let responder = libmdns::Responder::new().unwrap();

let services = responder.services_manager();
let _service = services.register(...);

// Because Responder: Future<Item=(), Error=io::Error>
let responder = responder.map_err(|err| {
    println!("responder error {:?}", err);
});

tokio::run(responder);

// -- In another thread --
// (Un)Registering is still possible from wherever thanks to ServicesManager:
let _service = services.register(...);
```
Which looks more like tokio's [hello_world](https://github.com/tokio-rs/tokio/blob/master/examples/hello_world.rs).

What are your thoughts on this?

Disclaimer: I have basically no knowledge of the tokio ecosystem, and mostly looked at [rtsp-rs](https://github.com/sgodwincs/rtsp-rs/)' API.