### PR TITLE
SO_REUSEPORT not supported on linux < 3.9

### DIFF
--- a/src/address_family.rs
+++ b/src/address_family.rs
@@ -14,7 +14,7 @@ pub trait AddressFamily {
         let builder = Self::socket_builder()?;
         builder.reuse_address(true)?;
         #[cfg(not(windows))]
-        builder.reuse_port(true)?;
+        let _ = builder.reuse_port(true);
         let socket = builder.bind(&addr)?;
         Self::join_multicast(&socket)?;
         Ok(socket)


### PR DESCRIPTION
Upstream cherry pick of plietar/rust-mdns#24